### PR TITLE
The survey navigation logic

### DIFF
--- a/src/components/survey/EntryReviewStepContent.tsx
+++ b/src/components/survey/EntryReviewStepContent.tsx
@@ -23,10 +23,10 @@ const EntryReviewStepContent: React.FC = () => {
     error: contextError,
     goToNextStep,
     completeSurveyAndPersistData,
+    currentDisplayEntry,
   } = useSurveyProgress();
 
   const {
-    currentDisplayEntry,
     optionAContent,
     optionBContent,
     optionAisDPOAccepted,

--- a/src/components/survey/EntryReviewStepContent.tsx
+++ b/src/components/survey/EntryReviewStepContent.tsx
@@ -17,15 +17,13 @@ const EntryReviewStepContent: React.FC = () => {
     currentDpoEntryIndex,
     isLoadingEntries,
     participantSessionUid,
-    // markCurrentEvaluationSubmitted, // <--- Consider removing, handled by SET_EVALUATION now
     isCurrentEvaluationSubmitted,
     error: contextError,
     goToNextStep,
     completeSurveyAndPersistData,
     currentDisplayEntry,
-    // --- ADD updateDpoEntryUserState HERE ---
     updateDpoEntryUserState,
-  } = useSurveyProgress(); // This is where updateDpoEntryUserState comes from
+  } = useSurveyProgress();
 
   const {
     optionAContent,
@@ -34,11 +32,11 @@ const EntryReviewStepContent: React.FC = () => {
     selectedOptionKey,
     setSelectedOptionKey,
     agreementRating,
-    setAgreementRating, // Still needed for local state update by handleSetAgreementRating
+    setAgreementRating,
     userComment,
-    setUserComment, // Still needed for local state update by handleSetUserComment
+    setUserComment,
     selectedCategories,
-    setSelectedCategories, // Still needed for local state update by handleSetSelectedCategories
+    setSelectedCategories,
     timeStarted,
     localError,
     setLocalError,
@@ -49,10 +47,8 @@ const EntryReviewStepContent: React.FC = () => {
   const { startTour, shouldShowTour } = useSurveyTour();
   const [isFlagModalOpen, setIsFlagModalOpen] = useState(false);
 
-  // Start tour when first entry loads (only if user hasn't seen it before)
   useEffect(() => {
     if (currentDisplayEntry?.id && currentDpoEntryIndex === 0 && !isCurrentEvaluationSubmitted && shouldShowTour) {
-      // Small delay to ensure DOM is ready
       const timer = setTimeout(() => {
         startTour();
       }, 500);
@@ -70,16 +66,14 @@ const EntryReviewStepContent: React.FC = () => {
 
   const handleOptionSelect = useCallback(
     (optionKey: 'A' | 'B') => {
-      // It's crucial to check isUserEvaluationSubmitted from currentDisplayEntry
-      // because isCurrentEvaluationSubmitted might be for the previous entry.
-      if (currentDisplayEntry?.isUserEvaluationSubmitted || isRevealed) return; // Use currentDisplayEntry's state for this
+      if (currentDisplayEntry?.isUserEvaluationSubmitted || isRevealed) return;
       setSelectedOptionKey(optionKey);
       setLocalError(null);
       if (currentDisplayEntry?.id) {
         updateDpoEntryUserState(currentDisplayEntry.id, { userSelectedOptionKey: optionKey });
       }
     },
-    [currentDisplayEntry, isRevealed, setSelectedOptionKey, setLocalError, updateDpoEntryUserState], // Add currentDisplayEntry and updateDpoEntryUserState to dependencies
+    [currentDisplayEntry, isRevealed, setSelectedOptionKey, setLocalError, updateDpoEntryUserState],
   );
 
   const handleSetAgreementRating = useCallback(
@@ -152,26 +146,12 @@ const EntryReviewStepContent: React.FC = () => {
       return;
     }
 
-    // Always use currentDisplayEntry directly, as it's kept up-to-date by the reducer
-    // and correctly reflects the current entry being displayed.
     if (!currentDisplayEntry || !currentDisplayEntry.id) {
-      // Use currentDisplayEntry.id for validation
       setLocalError('No current entry to submit evaluation for.');
       return;
     }
 
-    submitEvaluationToContext(result, currentDisplayEntry); // Pass currentDisplayEntry directly
-
-    // markCurrentEvaluationSubmitted(); // <--- This line is likely no longer needed.
-    // The SET_EVALUATION action in reducer now handles
-    // marking isUserEvaluationSubmitted: true on the DPOEntry
-    // and useEntryReviewState will pick it up.
-
-    // Redundant but safe: Ensure the DPOEntry in state reflects the submitted state.
-    // The SET_EVALUATION action in the reducer already handles this robustly,
-    // but an explicit dispatch here can act as a fallback/reinforcement.
-    // If you're confident in the SET_EVALUATION reducer logic, you could omit this block.
-    // However, it doesn't hurt.
+    submitEvaluationToContext(result, currentDisplayEntry);
     updateDpoEntryUserState(currentDisplayEntry.id, {
       isUserEvaluationSubmitted: true,
       userSelectedOptionKey: selectedOptionKey,
@@ -188,21 +168,21 @@ const EntryReviewStepContent: React.FC = () => {
     } else {
       goToNextStep();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    currentDisplayEntry, // Crucial dependency for all these changes
+    currentDisplayEntry,
     selectedOptionKey,
     agreementRating,
     userComment,
-    timeStarted,
     optionAisDPOAccepted,
     selectedCategories,
-    dpoEntriesToReview, // Needed for `isLastEntry` check
-    currentDpoEntryIndex, // Needed for `isLastEntry` check
+    dpoEntriesToReview,
+    currentDpoEntryIndex,
     submitEvaluationToContext,
     setLocalError,
     goToNextStep,
     completeSurveyAndPersistData,
-    updateDpoEntryUserState, // New dependency
+    updateDpoEntryUserState,
   ]);
 
   const handleSubmitFlag = useCallback(
@@ -223,8 +203,6 @@ const EntryReviewStepContent: React.FC = () => {
     [participantSessionUid, currentDisplayEntry, setIsFlagModalOpen],
   );
 
-  // canReveal and canSubmit can also check currentDisplayEntry.isUserEvaluationSubmitted
-  // if you want to prevent actions on already submitted entries.
   const canReveal: boolean = Boolean(
     selectedOptionKey &&
       selectedCategories.length > 0 &&
@@ -236,7 +214,6 @@ const EntryReviewStepContent: React.FC = () => {
   );
 
   const researcherOptionKey = optionAisDPOAccepted ? 'A' : 'B';
-  // userChoiceMatchesResearcher should also look at currentDisplayEntry.isUserEvaluationSubmitted
   const userChoiceMatchesResearcher =
     (isRevealed || (currentDisplayEntry?.isUserEvaluationSubmitted ?? false)) &&
     selectedOptionKey === researcherOptionKey;
@@ -251,9 +228,7 @@ const EntryReviewStepContent: React.FC = () => {
           currentStepNumber={currentStepNumber}
           totalSteps={totalSteps}
           isLoadingEntries={isLoadingEntries}
-          // The prop passed here should reflect the current entry's submission status
-          // which is now primarily driven by currentDisplayEntry.isUserEvaluationSubmitted
-          isCurrentEvaluationSubmitted={currentDisplayEntry?.isUserEvaluationSubmitted || false} // <--- IMPORTANT CHANGE
+          isCurrentEvaluationSubmitted={currentDisplayEntry?.isUserEvaluationSubmitted || false}
           isRevealed={isRevealed}
           selectedOptionKey={selectedOptionKey}
           agreementRating={agreementRating}
@@ -269,11 +244,9 @@ const EntryReviewStepContent: React.FC = () => {
           optionAContent={optionAContent}
           optionBContent={optionBContent}
           handleOptionSelect={handleOptionSelect}
-          // --- PASS NEW HANDLERS TO CONTENT VIEW ---
-          setAgreementRating={handleSetAgreementRating} // Use new handler
-          setUserComment={handleSetUserComment} // Use new handler
-          setSelectedCategories={handleSetSelectedCategories} // Use new handler
-          // --- END NEW HANDLERS ---
+          setAgreementRating={handleSetAgreementRating}
+          setUserComment={handleSetUserComment}
+          setSelectedCategories={handleSetSelectedCategories}
           handleReveal={handleReveal}
           handleLocalSubmit={handleLocalSubmit}
           setIsFlagModalOpen={setIsFlagModalOpen}

--- a/src/components/survey/EntryReviewStepContentView.tsx
+++ b/src/components/survey/EntryReviewStepContentView.tsx
@@ -13,7 +13,6 @@ import ReviewHeader from './ReviewHeader';
 import SubmitButton from './SubmitButton';
 
 interface EntryReviewStepContentViewProps {
-  // Data
   currentDisplayEntry: DPOEntry | null;
   currentDpoEntryIndex: number;
   dpoEntriesToReview: DPOEntry[];
@@ -35,8 +34,6 @@ interface EntryReviewStepContentViewProps {
   researcherOptionKey: 'A' | 'B';
   optionAContent: string;
   optionBContent: string;
-
-  // Handlers
   handleOptionSelect: (optionKey: 'A' | 'B') => void;
   setAgreementRating: (rating: number) => void;
   setUserComment: (comment: string) => void;

--- a/src/components/survey/useEntryReviewState.ts
+++ b/src/components/survey/useEntryReviewState.ts
@@ -3,53 +3,44 @@ import { useEffect, useState } from 'react';
 import { useSurveyProgress } from '../../contexts/SurveyProgressContext';
 
 export function useEntryReviewState() {
-  const { currentDisplayEntry, dpoEntriesToReview, currentDpoEntryIndex, evaluations, isCurrentEvaluationSubmitted } =
-    useSurveyProgress();
-
-  const currentEntry = dpoEntriesToReview[currentDpoEntryIndex];
-  const existingEvaluation = evaluations.find((evaluation) => evaluation.dpoEntryId === currentEntry?.id);
+  const { currentDisplayEntry } = useSurveyProgress();
 
   const [selectedOptionKey, setSelectedOptionKey] = useState<'A' | 'B' | null>(
-    existingEvaluation ? existingEvaluation.chosenOptionKey : null,
+    currentDisplayEntry?.userSelectedOptionKey || null,
   );
-  const [agreementRating, setAgreementRating] = useState<number>(
-    existingEvaluation ? existingEvaluation.agreementRating : 0,
-  );
-  const [userComment, setUserComment] = useState<string>(existingEvaluation ? existingEvaluation.comment || '' : '');
+  const [agreementRating, setAgreementRating] = useState<number>(currentDisplayEntry?.userAgreementRating || 0);
+  const [userComment, setUserComment] = useState<string>(currentDisplayEntry?.userComment || '');
   const [selectedCategories, setSelectedCategories] = useState<string[]>(
-    existingEvaluation ? existingEvaluation.categories : [],
+    currentDisplayEntry?.userSelectedCategories || [],
   );
   const [localError, setLocalError] = useState<string | null>(null);
-  const [isRevealed, setIsRevealed] = useState<boolean>(existingEvaluation ? true : false);
+  const [isRevealed, setIsRevealed] = useState<boolean>(currentDisplayEntry?.isUserRevealed || false);
+
+  const [timeStarted, setTimeStarted] = useState<number>(Date.now());
 
   const optionAContent = currentDisplayEntry?.acceptedResponse || '';
   const optionBContent = currentDisplayEntry?.rejectedResponse || '';
   const optionAisDPOAccepted = currentDisplayEntry?.acceptedResponse ? true : false;
 
   useEffect(() => {
-    if (currentEntry) {
-      const evalForEntry = evaluations.find((evaluation) => evaluation.dpoEntryId === currentEntry.id);
-      if (evalForEntry) {
-        setSelectedOptionKey(evalForEntry.chosenOptionKey);
-        setAgreementRating(evalForEntry.agreementRating);
-        setUserComment(evalForEntry.comment || '');
-        setSelectedCategories(evalForEntry.categories);
-        setIsRevealed(true);
+    if (currentDisplayEntry) {
+      setSelectedOptionKey(currentDisplayEntry.userSelectedOptionKey || null);
+      setAgreementRating(currentDisplayEntry.userAgreementRating || 0);
+      setUserComment(currentDisplayEntry.userComment || '');
+      setSelectedCategories(currentDisplayEntry.userSelectedCategories || []);
+      setIsRevealed(currentDisplayEntry.isUserRevealed || false);
 
-        if (!isCurrentEvaluationSubmitted) {
-        }
-      } else {
-        setSelectedOptionKey(null);
-        setAgreementRating(0);
-        setUserComment('');
-        setSelectedCategories([]);
-        setIsRevealed(false);
-      }
-      setLocalError(null);
+      setTimeStarted(Date.now());
+    } else {
+      setSelectedOptionKey(null);
+      setAgreementRating(0);
+      setUserComment('');
+      setSelectedCategories([]);
+      setIsRevealed(false);
+      setTimeStarted(Date.now());
     }
-  }, [currentDpoEntryIndex, currentEntry, evaluations, isCurrentEvaluationSubmitted]);
-
-  const timeStarted = Date.now();
+    setLocalError(null);
+  }, [currentDisplayEntry]);
 
   return {
     currentDisplayEntry,

--- a/src/components/survey/useEntryReviewState.ts
+++ b/src/components/survey/useEntryReviewState.ts
@@ -29,7 +29,6 @@ export function useEntryReviewState() {
       setUserComment(currentDisplayEntry.userComment || '');
       setSelectedCategories(currentDisplayEntry.userSelectedCategories || []);
       setIsRevealed(currentDisplayEntry.isUserRevealed || false);
-
       setTimeStarted(Date.now());
     } else {
       setSelectedOptionKey(null);

--- a/src/contexts/SurveyProgressContext.tsx
+++ b/src/contexts/SurveyProgressContext.tsx
@@ -1,4 +1,3 @@
-// contexts/SurveyProgressContext.tsx
 'use client';
 
 import type { ReactNode } from 'react';

--- a/src/lib/survey/actions.ts
+++ b/src/lib/survey/actions.ts
@@ -17,6 +17,7 @@ export enum SurveyActionType {
   COMPLETE_SURVEY = 'COMPLETE_SURVEY',
   RESET_SURVEY = 'RESET_SURVEY',
   SET_UNSAVED_CHANGES = 'SET_UNSAVED_CHANGES',
+  UPDATE_DPO_ENTRY_USER_STATE = 'UPDATE_DPO_ENTRY_USER_STATE',
 }
 
 export type SurveyAction =
@@ -38,4 +39,11 @@ export type SurveyAction =
   | { type: SurveyActionType.SET_SUBMITTING; payload: boolean }
   | { type: SurveyActionType.COMPLETE_SURVEY }
   | { type: SurveyActionType.RESET_SURVEY }
-  | { type: SurveyActionType.SET_UNSAVED_CHANGES; payload: boolean };
+  | { type: SurveyActionType.SET_UNSAVED_CHANGES; payload: boolean }
+  | {
+      type: SurveyActionType.UPDATE_DPO_ENTRY_USER_STATE;
+      payload: {
+        entryId: string;
+        updates: Partial<DPOEntry>;
+      };
+    };

--- a/src/lib/survey/hooks/useSurveyMutations.ts
+++ b/src/lib/survey/hooks/useSurveyMutations.ts
@@ -15,6 +15,7 @@ export interface UseSurveyMutations {
   updateDemographicsInContext: (data: DemographicData) => void;
   submitEvaluation: (evaluationDraft: EvaluationDraft, currentEntry: DPOEntry) => void;
   completeSurveyAndPersistData: () => Promise<void>;
+  updateDpoEntryUserState: (entryId: string, updates: Partial<DPOEntry>) => void;
 }
 
 export function useSurveyMutations(state: SurveyState, dispatch: Dispatch<SurveyAction>): UseSurveyMutations {
@@ -107,11 +108,25 @@ export function useSurveyMutations(state: SurveyState, dispatch: Dispatch<Survey
     }
   }, [state, dispatch]);
 
+  const updateDpoEntryUserState = useCallback(
+    (entryId: string, updates: Partial<DPOEntry>) => {
+      dispatch({
+        type: SurveyActionType.UPDATE_DPO_ENTRY_USER_STATE,
+        payload: {
+          entryId,
+          updates,
+        },
+      });
+    },
+    [dispatch],
+  );
+
   return {
     setParticipationDetails,
     setParticipantEmail,
     updateDemographicsInContext,
     submitEvaluation,
     completeSurveyAndPersistData,
+    updateDpoEntryUserState,
   };
 }

--- a/src/types/dpo.ts
+++ b/src/types/dpo.ts
@@ -59,6 +59,14 @@ export interface DPOEntry {
   originalEntryId?: string; // If this entry is a new version, this links to the ID of the entry it corrects/revises
   supersededByEntryId?: string; // If this entry is archived, this links to the ID of the new entry that replaces it
   viewCount?: number;
+  // --- START: NEW FIELDS FOR USER'S INTERACTION STATE ---
+  userSelectedOptionKey?: 'A' | 'B' | null; // Stores 'A' or 'B' (the chosen option)
+  userAgreementRating?: number; // Stores the user's rating (0-5)
+  userComment?: string | null; // Stores the user's comment
+  userSelectedCategories?: string[]; // Stores the array of categories selected by the user
+  isUserRevealed?: boolean; // True if the user has clicked "Reveal" for this entry
+  isUserEvaluationSubmitted?: boolean; // True if the user has submitted evaluation for this entry
+  // --- END: NEW FIELDS FOR USER'S INTERACTION STATE ---
 }
 
 export interface DemographicData {

--- a/src/types/survey.ts
+++ b/src/types/survey.ts
@@ -17,6 +17,7 @@ export interface SurveyState {
   isSubmittingSurvey: boolean;
   isCurrentEvaluationSubmitted: boolean;
   hasUnsavedChanges: boolean;
+  currentDisplayEntry: DPOEntry | null;
 }
 
 export interface SurveyAction {

--- a/src/types/survey.ts
+++ b/src/types/survey.ts
@@ -40,4 +40,5 @@ export interface SurveyContextValue extends SurveyState {
   setGlobalError: (message: string | null) => void;
   resetSurvey: () => void;
   setHasUnsavedChanges: (hasChanges: boolean) => void;
+  updateDpoEntryUserState: (entryId: string, updates: Partial<DPOEntry>) => void;
 }


### PR DESCRIPTION
The survey navigation logic was modified to allow users to go back to previous questions. When navigating backward, previously selected answers are now preserved and displayed, making it easier for users to review and modify their responses before submitting the form.

Main changes:

Implemented backward navigation in the survey flow.

Updated the state handling to persist answers across steps, even when going back.

Adjusted the UI to display previously selected answers when returning to a question.